### PR TITLE
allメソッドを使っているところをfind_eachに変更

### DIFF
--- a/lib/comparer.rb
+++ b/lib/comparer.rb
@@ -11,7 +11,7 @@ module Comparer
       logger = Logger.new('log/crawler.log')
 
       data = []
-      Book.all.each do |book|
+      Book.find_each do |book|
         amazon = AmazonCrawler.new
         dmm = DmmCrawler.new
         rakuten = RakutenCrawler.new


### PR DESCRIPTION
## 対応理由
現在は小規模なので問題ないと思うが、今後データが数千件を超えた時、`all`だとデータを一気にメモリに読み込んでしまうことが懸念される。
`find_each`を使えば、どれだけデータがあっても一度にメモリに読み込まれるのは1,000件と決まっているので、将来を見越して今のうちから`find_each`にしておく。