### PR TITLE
リストから本を削除した時に他のリストに登録されていなければ本をDBから削除

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,10 @@ NestedGroups:
   Exclude:
     - spec/**/*
 
+RSpec/NamedSubject:
+  Exclude:
+    - spec/**/*
+
 RSpec/ExampleLength:
   Exclude:
     - spec/system/*

--- a/app/controllers/api/list_details_controller.rb
+++ b/app/controllers/api/list_details_controller.rb
@@ -23,6 +23,8 @@ class API::ListDetailsController < API::BaseController
     list_detail = ListDetail.find(params[:id])
 
     if list_detail.destroy
+      list_detail.book.not_in_list_details_destroy!
+
       render status: :ok,
              json: { successMessage: '削除しました。' }
     else

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -9,4 +9,8 @@ class Book < ApplicationRecord
   validates :title, presence: true
   validates :image, presence: true
   validates :url, presence: true
+
+  def not_in_list_details_destroy!
+    destroy! if list_details.empty?
+  end
 end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -101,4 +101,26 @@ RSpec.describe Book, type: :model do
       end
     end
   end
+
+  describe '#not_in_list_details_destroy!' do
+    subject { book.not_in_list_details_destroy! }
+
+    let!(:book) { create(:cherry) }
+
+    context '他のリストに登録されていない場合' do
+      it 'DBから削除されること' do
+        expect { subject }.to change(described_class, :count).by(-1)
+      end
+    end
+
+    context '他のリストに登録されている場合' do
+      before do
+        create(:list_detail_one, book: book)
+      end
+
+      it 'DBから削除されないこと' do
+        expect { subject }.not_to change(described_class, :count)
+      end
+    end
+  end
 end


### PR DESCRIPTION
現状だとどのリストにも登録されていない本がDBに残り続けてしまっている。
この状態が続くとDB容量を圧迫するし、クローラーが走る度に無駄なDBアクセスが発生してしまう。

この問題を解消するために、リストから本が削除された際に、その本が他のリストに登録されているかを確認し登録されていなければ本をDBから削除する処理を追加する。
これによってDBに登録されている本は、すべて「いずれかのリストに登録されている本」である状態を維持できる。