### PR TITLE
テスト用の workflow にビルドコマンドを追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
         docker-compose build
         docker-compose run web yarn install --check-files
         docker-compose run web yarn upgrade
+        docker-compose run web yarn build
         docker-compose run web echo ${{ secrets.RAILS_MASTER_KEY }} >> config/master.key
         docker-compose run web bin/rails db:create
       


### PR DESCRIPTION
webpacker から jsbundling-rails に乗り換えたことで、js の読み込みができなくなってテストが落ちるようになった。
テストの実行前に build を挟むようにする。