### PR TITLE
ログイン中のみログアウトリンクが表示されるように修正した

### DIFF
--- a/app/views/application/_footer.html.slim
+++ b/app/views/application/_footer.html.slim
@@ -4,9 +4,10 @@ footer.footer.px-4.py-5
       = link_to '利用規約', tos_path, class: 'mx-3'
     li.footer-item
       = link_to 'プライバシーポリシー', privacy_policy_path, class: 'mx-3'
-    li.footer-item
-      / NOTE: Turbo を有効にできないので button_to でお茶を濁している
-      = button_to 'ログアウト', :destroy_user_session, method: :delete, class: 'mx-3 break'
+    - if user_signed_in?
+      li.footer-item
+        / NOTE: Turbo を有効にできないので button_to でお茶を濁している
+        = button_to 'ログアウト', :destroy_user_session, method: :delete, class: 'mx-3 break'
 
   ul.block.is-flex.is-justify-content-center
     li.footer-item

--- a/spec/system/application_spec.rb
+++ b/spec/system/application_spec.rb
@@ -56,4 +56,23 @@ RSpec.describe 'application', type: :system do
       end
     end
   end
+
+  describe 'footer menu' do
+    context 'ログイン済みの場合' do
+      let(:user) { create(:alice) }
+
+      it 'ログアウトリンクが表示されること' do
+        login(user)
+        visit root_path
+        expect(page).to have_button 'ログアウト'
+      end
+    end
+
+    context '未ログインの場合' do
+      it 'ログアウトリンクが表示されないこと' do
+        visit root_path
+        expect(page).not_to have_button 'ログアウト'
+      end
+    end
+  end
 end


### PR DESCRIPTION
ref: #219 

これまでログイン状態に関わらず(ログインしていなくても)、フッターに「ログアウト」リンクが表示されてしまっていた。
ログインしていないのにログアウトリンクが表示されるのはおかしいしエラーになってしまうので、ログイン状態の時のみ表示されるように修正する。