### PR TITLE
Google ログインができないバグを修正

### DIFF
--- a/app/views/devise/shared/_links.html.slim
+++ b/app/views/devise/shared/_links.html.slim
@@ -1,6 +1,6 @@
 - if devise_mapping.omniauthable?
   - resource_class.omniauth_providers.each do |provider|
-    = link_to omniauth_authorize_path(resource_name, provider), method: :post, class: 'button max mt-4'
+    = button_to omniauth_authorize_path(resource_name, provider), method: :post, class: 'button max mt-4'
       img.icon src='/g-logo.png'
       - if controller_name == 'registrations'
         span Googleアカウントで登録


### PR DESCRIPTION
ref: #244 

原因は google-oauth へのアクセスは post メソッドにする必要があるところ、Rails 7 にして rails-ujs を使わなくなったことで、`link_to ... method: :post` が動作しなくなっていたこと。
Google ログインボタンを `link_to` から `button_to` に変更することで改善しそう。